### PR TITLE
feature/enable rc versions

### DIFF
--- a/semantic-version-gradle-plugin/src/main/java/com/semanticversion/gradle/plugin/SemanticVersionExtension.kt
+++ b/semantic-version-gradle-plugin/src/main/java/com/semanticversion/gradle/plugin/SemanticVersionExtension.kt
@@ -16,4 +16,5 @@ open class SemanticVersionExtension(propertyResolver: PropertyResolver) {
     var snapshot: Boolean? = propertyResolver.getBooleanProp(::snapshot.name)
     var beta: Boolean? = propertyResolver.getBooleanProp(::beta.name)
     var alpha: Boolean? = propertyResolver.getBooleanProp(::alpha.name)
+    var releaseCandidate: Boolean? = propertyResolver.getBooleanProp(::releaseCandidate.name)
 }

--- a/semantic-version-gradle-plugin/src/main/java/com/semanticversion/gradle/plugin/SemanticVersionGradlePlugin.kt
+++ b/semantic-version-gradle-plugin/src/main/java/com/semanticversion/gradle/plugin/SemanticVersionGradlePlugin.kt
@@ -35,7 +35,7 @@ open class SemanticVersionGradlePlugin : Plugin<Project> {
             extension = project.extensions.create(EXTENSION_NAME, getExtensionClass(), project.propertyResolver)
 
             baseVersion = Version(project.version.toString()).baseVersion
-            val version = Version(baseVersion, SemanticVersionConfig(extension.maximumVersion, extension.versionClassifier, extension.snapshot, extension.beta, extension.alpha))
+            val version = Version(baseVersion, SemanticVersionConfig(extension.maximumVersion, extension.versionClassifier, extension.snapshot, extension.beta, extension.alpha, extension.releaseCandidate))
             project.version = version.toString()
 
             val incrementVersionTask = project.tasks.create(IncrementVersionTask.TASK_NAME, IncrementVersionTask::class.java)

--- a/semantic-version-gradle-plugin/src/main/java/com/semanticversion/gradle/plugin/increment/IncrementVersionHelper.kt
+++ b/semantic-version-gradle-plugin/src/main/java/com/semanticversion/gradle/plugin/increment/IncrementVersionHelper.kt
@@ -11,7 +11,7 @@ import java.io.File
 object IncrementVersionHelper {
 
     fun increment(
-        project: Project,
+        projectName: String,
         versionFile: File,
         versionIncrementType: VersionIncrementType,
         versionIncrementBranch: String?,
@@ -51,10 +51,10 @@ object IncrementVersionHelper {
                 }
                 gitHelper.add(versionFile.absolutePath)
                 gitHelper.diffHead()
-                gitHelper.commit(commitMessagePrefix.orEmpty() + "Version for project ${project.name} is now v${newVersion.toString()}")
+                gitHelper.commit(commitMessagePrefix.orEmpty() + "Version for project ${projectName} is now v${newVersion.toString()}")
 
                 if (includeTag == true) {
-                    gitHelper.tag("${project.name}@${newVersion.toString()}", "Version for project ${project.name} is now v${newVersion.toString()}")
+                    gitHelper.tag("${projectName}@${newVersion.toString()}", "Version for project ${projectName} is now v${newVersion.toString()}")
                     gitHelper.pushWithTag(versionIncrementBranch);
                 } else {
                     gitHelper.push(versionIncrementBranch)

--- a/semantic-version-gradle-plugin/src/main/java/com/semanticversion/gradle/plugin/increment/IncrementVersionTask.kt
+++ b/semantic-version-gradle-plugin/src/main/java/com/semanticversion/gradle/plugin/increment/IncrementVersionTask.kt
@@ -52,7 +52,7 @@ open class IncrementVersionTask : AbstractTask() {
 
         val buildGradleFile = project.buildFile
         val newVersion = IncrementVersionHelper.increment(
-            project,
+            project.name,
             buildGradleFile,
             VersionIncrementType.valueOf(versionIncrementType!!.toUpperCase()),
             versionIncrementBranch,

--- a/semantic-version-gradle-plugin/src/test/java/com/semanticversion/gradle/plugin/increment/IncrementVersionHelperTest.kt
+++ b/semantic-version-gradle-plugin/src/test/java/com/semanticversion/gradle/plugin/increment/IncrementVersionHelperTest.kt
@@ -8,6 +8,8 @@ import java.io.File
 
 class IncrementVersionHelperTest {
 
+    val projectName = "projectTest"
+
     @Test
     fun `GIVEN a version file WHEN incrementing the major THEN the version is properly incremented`() {
         testIncrement("version = \"1.0.0\"\n", VersionIncrementType.MAJOR, "2.0.0", "version = \"2.0.0\"\n")
@@ -60,9 +62,11 @@ class IncrementVersionHelperTest {
         versionFile.writeText(versionFileContent)
 
         val newVersion = IncrementVersionHelper.increment(
+            projectName,
             versionFile,
             versionIncrementType,
             null,
+            false,
             null,
             null,
             null,
@@ -78,9 +82,11 @@ class IncrementVersionHelperTest {
         versionFile.writeText(versionFileContent)
 
         IncrementVersionHelper.increment(
+            projectName,
             versionFile,
             versionIncrementType,
             null,
+            false,
             null,
             null,
             null,

--- a/semantic-version/src/main/java/com/semanticversion/SemanticVersionConfig.kt
+++ b/semantic-version/src/main/java/com/semanticversion/SemanticVersionConfig.kt
@@ -5,7 +5,8 @@ open class SemanticVersionConfig(
     var versionClassifier: String? = null,
     var snapshot: Boolean? = null,
     var beta: Boolean? = null,
-    var alpha: Boolean? = null
+    var alpha: Boolean? = null,
+    var releaseCandidate: Boolean? = null
 )
 
 // var featureBranchPrefix: String? = propertyResolver.getStringProp(::featureBranchPrefix.name)

--- a/semantic-version/src/main/java/com/semanticversion/Version.kt
+++ b/semantic-version/src/main/java/com/semanticversion/Version.kt
@@ -7,6 +7,7 @@ open class Version {
         const val SNAPSHOT_CLASSIFIER = "SNAPSHOT"
         const val BETA_CLASSIFIER = "BETA"
         const val ALPHA_CLASSIFIER = "ALPHA"
+        const val RC_CLASSIFIER = "RC"
         const val BASE_VERSION_SEPARATOR = "."
         // const val LOCAL_CLASSIFIER = "LOCAL"
         // const val VERSION_TIMESTAMP_FORMAT = "YYYYMMddHHmmss"
@@ -15,10 +16,12 @@ open class Version {
     var versionMajor: Int? = null
     var versionMinor: Int? = null
     var versionPatch: Int? = null
+    var versionReleaseCandidate: Int? = null
     var versionClassifier: String? = null
     var isSnapshot: Boolean = true
     var isBeta: Boolean = false
     var isAlpha: Boolean = false
+    var isReleaseCandidate: Boolean = false
 
     // TODO Add support to this
     // var isVersionTimestampEnabled: Boolean = false
@@ -42,22 +45,36 @@ open class Version {
         validateBaseVersion()
     }
 
+    constructor(versionMajor: Int, versionMinor: Int, versionPatch: Int, versionReleaseCandidate: Int) {
+        maximumVersion = defaultMaximumVersion
+        this.versionMajor = versionMajor
+        this.versionMinor = versionMinor
+        this.versionPatch = versionPatch
+        this.versionReleaseCandidate = versionReleaseCandidate
+        validateBaseVersion()
+    }
+
     constructor(version: String) {
         maximumVersion = defaultMaximumVersion
         val split = version.split(VERSION_CLASSIFIER_SEPARATOR)
-        val baseVersion = split[0]
-        parseBaseVersion(baseVersion)
         if (split.size > 1) {
+            parseBaseVersion(split[0])
             versionClassifier = split[1]
             parseVersionClassifier(versionClassifier!!)
             // isLocal = versionClassifier == LOCAL_CLASSIFIER
             // isVersionTimestampEnabled = false
         } else {
-            isSnapshot = false
-            isAlpha = false
-            isBeta = false
-            // isLocal = false
-            // isVersionTimestampEnabled = false
+            if (version.contains(RC_CLASSIFIER)) {
+                parseBaseVersion(version)
+            } else {
+                parseBaseVersion(split[0])
+                isSnapshot = false
+                isAlpha = false
+                isBeta = false
+                isReleaseCandidate = false
+                // isLocal = false
+                // isVersionTimestampEnabled = false
+            }
         }
     }
 
@@ -107,6 +124,7 @@ open class Version {
                 isAlpha = true
                 isBeta = false
                 isSnapshot = false
+                isReleaseCandidate = false
             } else {
                 if (config.beta == true) {
                     versionClassifier = BETA_CLASSIFIER
@@ -114,17 +132,27 @@ open class Version {
                     isAlpha = false
                     isBeta = true
                     isSnapshot = false
+                    isReleaseCandidate = false
                 } else {
-                    if (config.snapshot == true || config.snapshot == null) {
+                    if (config.snapshot == true) {
                         versionClassifier = SNAPSHOT_CLASSIFIER
 
                         isAlpha = false
                         isBeta = false
                         isSnapshot = true
+                        isReleaseCandidate = false
                     } else {
-                        isAlpha = false
-                        isBeta = false
-                        isSnapshot = false
+                        if (config.releaseCandidate == true) {
+                            isAlpha = false
+                            isBeta = false
+                            isSnapshot = false
+                            isReleaseCandidate = true
+                        } else {
+                            isAlpha = false
+                            isBeta = false
+                            isSnapshot = false
+                            isReleaseCandidate = false
+                        }
                     }
                 }
             }
@@ -141,33 +169,52 @@ open class Version {
                 isSnapshot = false
                 isBeta = false
                 isAlpha = true
+                isReleaseCandidate = false
             }
             BETA_CLASSIFIER -> {
                 isSnapshot = false
                 isBeta = true
                 isAlpha = false
+                isReleaseCandidate = false
             }
             SNAPSHOT_CLASSIFIER -> {
                 isSnapshot = true
                 isBeta = false
                 isAlpha = false
+                isReleaseCandidate = false
+            }
+            RC_CLASSIFIER -> {
+                isSnapshot = false
+                isBeta = false
+                isAlpha = false
+                isReleaseCandidate = true
             }
             else -> {
                 isSnapshot = false
                 isBeta = false
                 isAlpha = false
+                isReleaseCandidate = false
             }
         }
     }
 
     private fun parseBaseVersion(baseVersion: String) {
         val versionSplit = baseVersion.split(BASE_VERSION_SEPARATOR)
-        if (versionSplit.size != 3) {
+        if (versionSplit.size < 3 || versionSplit.size > 5) {
             throw RuntimeException("The version [$baseVersion] is not a valid Semantic Versioning")
         }
-        versionMajor = versionSplit[0].toInt()
-        versionMinor = versionSplit[1].toInt()
-        versionPatch = versionSplit[2].toInt()
+
+        if (versionSplit.size == 3) {
+            versionMajor = versionSplit[0].toInt()
+            versionMinor = versionSplit[1].toInt()
+            versionPatch = versionSplit[2].toInt()
+        } else if (versionSplit.size == 5) {
+            versionMajor = versionSplit[0].toInt()
+            versionMinor = versionSplit[1].toInt()
+            versionPatch = versionSplit[2].toInt()
+            versionReleaseCandidate = versionSplit[4].toInt()
+        }
+
         validateBaseVersion()
     }
 
@@ -184,6 +231,7 @@ open class Version {
     }
 
     fun incrementMajor() {
+        resetReleaseCandidate()
         if (versionMajor!! < maximumVersion!!) {
             versionMajor = versionMajor!! + 1
             versionMinor = 0
@@ -194,6 +242,7 @@ open class Version {
     }
 
     fun incrementMinor() {
+        resetReleaseCandidate()
         if (versionMinor!! < maximumVersion!!) {
             versionMinor = versionMinor!! + 1
             versionPatch = 0
@@ -203,6 +252,7 @@ open class Version {
     }
 
     fun incrementPatch() {
+        resetReleaseCandidate()
         if (versionPatch!! < maximumVersion!!) {
             versionPatch = versionPatch!! + 1
         } else {
@@ -210,10 +260,33 @@ open class Version {
         }
     }
 
+    fun promoteReleaseCandidate() {
+        resetReleaseCandidate()
+    }
+
+    private fun resetReleaseCandidate() {
+        versionReleaseCandidate = null
+    }
+
+    fun incrementReleaseCandidate() {
+        if (versionReleaseCandidate != null) {
+            versionClassifier = RC_CLASSIFIER
+            versionReleaseCandidate = versionReleaseCandidate!! + 1
+        } else {
+            versionClassifier = RC_CLASSIFIER
+            versionReleaseCandidate = 0
+        }
+    }
+
     override fun toString(): String {
         var versionName = baseVersion
         if (!versionClassifier.isNullOrEmpty()) {
-            versionName += "$VERSION_CLASSIFIER_SEPARATOR$versionClassifier"
+
+            if (versionClassifier != RC_CLASSIFIER) {
+                versionName += "$VERSION_CLASSIFIER_SEPARATOR$versionClassifier"
+            } else {
+                versionName += "$BASE_VERSION_SEPARATOR$RC_CLASSIFIER$BASE_VERSION_SEPARATOR$versionReleaseCandidate"
+            }
         }
         return versionName
     }

--- a/semantic-version/src/main/java/com/semanticversion/VersionIncrementType.kt
+++ b/semantic-version/src/main/java/com/semanticversion/VersionIncrementType.kt
@@ -16,6 +16,16 @@ enum class VersionIncrementType {
         override fun increment(version: Version) {
             version.incrementPatch()
         }
+    },
+    RC {
+        override fun increment(version: Version) {
+            version.incrementReleaseCandidate()
+        }
+    },
+    RELEASE {
+        override fun increment(version: Version) {
+            version.promoteReleaseCandidate()
+        }
     };
 
     abstract fun increment(version: Version)


### PR DESCRIPTION
* Uses project name String value instead of the whole Project object

- Release Candidate versions are supported, meaning that when incrementVersion --incrementVersionType=RC is executed the RC.N suffix will be appended to the actual base version, if the version is already a RC version only N will be increased by 1 until major, minor, patch or release is passed as incrementVersionType, in that case RC.N will be discarted and specific version will be required.
- release version is supported, this only means that when the actual version is RC.N and you pass --incrementVersionType=release the subffix will be skipped but no version is will be increased.
- snapshots are not default anymore, to avoid any kind of mistake with release candidate versions snapshots are not defauklt anymore, you can use snpashots whn printing version with -Psnapshot=true as the original behaviour

Co-authored-by: Rodrigo Alexis Rodriguez <rodrigo.rodriguez@oxxofintech.com.mx>