### PR TITLE
bugfix: Fix including RC.N in RC builds and printVersion

### DIFF
--- a/semantic-version-gradle-plugin/src/main/java/com/semanticversion/gradle/plugin/SemanticVersionGradlePlugin.kt
+++ b/semantic-version-gradle-plugin/src/main/java/com/semanticversion/gradle/plugin/SemanticVersionGradlePlugin.kt
@@ -33,9 +33,7 @@ open class SemanticVersionGradlePlugin : Plugin<Project> {
             }
 
             extension = project.extensions.create(EXTENSION_NAME, getExtensionClass(), project.propertyResolver)
-
-            baseVersion = Version(project.version.toString()).baseVersion
-            val version = Version(baseVersion, SemanticVersionConfig(extension.maximumVersion, extension.versionClassifier, extension.snapshot, extension.beta, extension.alpha, extension.releaseCandidate))
+            val version = Version(project.version.toString(), SemanticVersionConfig(extension.maximumVersion, extension.versionClassifier, extension.snapshot, extension.beta, extension.alpha, extension.releaseCandidate))
             project.version = version.toString()
 
             val incrementVersionTask = project.tasks.create(IncrementVersionTask.TASK_NAME, IncrementVersionTask::class.java)

--- a/semantic-version/src/main/java/com/semanticversion/Version.kt
+++ b/semantic-version/src/main/java/com/semanticversion/Version.kt
@@ -81,7 +81,8 @@ open class Version {
 
     constructor(baseVersion: String, config: SemanticVersionConfig) {
         maximumVersion = config.maximumVersion ?: defaultMaximumVersion
-        parseBaseVersion(baseVersion)
+        var split = baseVersion.split(VERSION_CLASSIFIER_SEPARATOR)
+        parseBaseVersion(split[0])
 
         if (baseVersion.contains(RC_CLASSIFIER)) {
             versionClassifier = RC_CLASSIFIER

--- a/semantic-version/src/main/java/com/semanticversion/Version.kt
+++ b/semantic-version/src/main/java/com/semanticversion/Version.kt
@@ -18,7 +18,7 @@ open class Version {
     var versionPatch: Int? = null
     var versionReleaseCandidate: Int? = null
     var versionClassifier: String? = null
-    var isSnapshot: Boolean = true
+    var isSnapshot: Boolean = false
     var isBeta: Boolean = false
     var isAlpha: Boolean = false
     var isReleaseCandidate: Boolean = false
@@ -66,6 +66,7 @@ open class Version {
         } else {
             if (version.contains(RC_CLASSIFIER)) {
                 parseBaseVersion(version)
+                parseVersionClassifier(RC_CLASSIFIER)
             } else {
                 parseBaseVersion(split[0])
                 isSnapshot = false
@@ -82,7 +83,12 @@ open class Version {
         maximumVersion = config.maximumVersion ?: defaultMaximumVersion
         parseBaseVersion(baseVersion)
 
-        versionClassifier = config.versionClassifier
+        if (baseVersion.contains(RC_CLASSIFIER)) {
+            versionClassifier = RC_CLASSIFIER
+        } else {
+            versionClassifier = config.versionClassifier
+        }
+
         if (versionClassifier == null) {
             // featureBranchPrefix = config.featureBranchPrefix
             // if (!featureBranchPrefix.isNullOrEmpty()) {
@@ -281,7 +287,6 @@ open class Version {
     override fun toString(): String {
         var versionName = baseVersion
         if (!versionClassifier.isNullOrEmpty()) {
-
             if (versionClassifier != RC_CLASSIFIER) {
                 versionName += "$VERSION_CLASSIFIER_SEPARATOR$versionClassifier"
             } else {


### PR DESCRIPTION

- When a version in build.gradle is .RC.N then it should be included with the suffix and number as well, only for RCs; snapshots, alpha, beta, etcs is handled as originally was